### PR TITLE
Fixed issue #1 - OnRequestClose prop is not supplied.

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ export default class Loading extends Component {
             show = loading;
         }
         return (
-            <Modal transparent = {true} onRequestClose={null}
+            <Modal transparent = {true} onRequestClose={() => {}}
                    visible = {show}>
                 <View style = {styles.loadingView}>
                     <View style = {[styles.loading, {

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ export default class Loading extends Component {
             show = loading;
         }
         return (
-            <Modal transparent = {true}
+            <Modal transparent = {true} onRequestClose={null}
                    visible = {show}>
                 <View style = {styles.loadingView}>
                     <View style = {[styles.loading, {


### PR DESCRIPTION
This will prevent the warning "OnRequestClose prop is not supplied" to not appear in Android.